### PR TITLE
handle empty list

### DIFF
--- a/src/bencode.js
+++ b/src/bencode.js
@@ -87,6 +87,12 @@
       var obj = getType() === "list" ? [] : {};
 
       incrementCounter( 1 );
+
+      if ( bencodedString.charAt( counter ) === 'e' ) {
+        incrementCounter( 1 );
+        return obj;
+      }
+      
       var type = getType();
 
       while( counter < bencodedString.length ) {


### PR DESCRIPTION
Some torrents have empty lists (`le`). This patch make the parsing work in this case.
